### PR TITLE
Fix type-o in schema-union-type

### DIFF
--- a/docs/schema-union-type.md
+++ b/docs/schema-union-type.md
@@ -48,7 +48,7 @@ public class FooBarBaz
 }
 ```
 
-In order to make this more convenient and infer if an object type belongs to a union type set we backed in support for marker interfaces.
+In order to make this more convenient and infer if an object type belongs to a union type set we baked in support for marker interfaces.
 
 ```csharp
 public interface IFooBarBaz { }


### PR DESCRIPTION
Simple type-o fix for `backed` => `baked`