### PR TITLE
add union docs crossref to IsOfType

### DIFF
--- a/docs/schema-union-type.md
+++ b/docs/schema-union-type.md
@@ -60,3 +60,6 @@ public class FooBarBaz
 ```
 
 In this case the set is inferred from the types in the schema.
+
+The individual `ObjectType` types that participate in the union can have a custom logic defined to indicate whether or not the resolved type is a specific type. To implement this, use the `descriptor.IsOfType()` logic [explained here](https://hotchocolate.io/docs/code-first-object-type#isoftype)
+


### PR DESCRIPTION
Make it easier to understand how to implement custom type discrimination in unions.